### PR TITLE
Fixes to make it work for Windows.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,11 @@ classifiers =
 
 [options]
 zip_safe = True
-scripts = setuptools-py2cfg.py
+py_modules = setuptools_py2cfg 
 python_requires = >=3.3
 
 [options.extras_require]
 test = pytest
+
+[options.entry_points]
+console_scripts = setuptools_py2cfg = setuptools_py2cfg:mainerMain

--- a/setuptools_py2cfg.py
+++ b/setuptools_py2cfg.py
@@ -211,6 +211,8 @@ def extract_section(value):
     if isinstance(value, dict):
         return {k: list_semi(ensure_list(v)) for k, v in value.items()}
 
+def mainerMain():
+    print(main())
 
 if __name__ == '__main__':
-    print(main())
+    mainerMain()


### PR DESCRIPTION
Renamed package to make it importable.
Replaced `scripts` with `options.entry_points`.
closes #1