### PR TITLE
Allow setup.py to be merged with an existing cfg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/_build/
 
 # Testing
 .pytest_cache
+.tox

--- a/tests/test_py2cfg.py
+++ b/tests/test_py2cfg.py
@@ -161,7 +161,6 @@ def _setup_cfg_merge_params():
     return params
 
 
-@pytest.mark.xfail
 @pytest.mark.parametrize('files, expected', _setup_cfg_merge_params())
 def test_setup_cfg_merge(files, expected, tmpdir_cwd):
     generate_package(tmpdir_cwd, files)

--- a/tests/test_py2cfg.py
+++ b/tests/test_py2cfg.py
@@ -1,8 +1,12 @@
 import pytest
 import textwrap
+import os
+
 from pathlib import Path
 
 import setuptools_py2cfg
+
+from .util import generate_package, compare_configs, configs_to_str
 
 
 @pytest.fixture
@@ -13,6 +17,12 @@ def empty_setup_py(tmpdir):
 @pytest.fixture
 def testpkg1(request):
     return Path(request.fspath.dirname, 'testpkg1')
+
+
+@pytest.fixture
+def tmpdir_cwd(tmpdir):
+    with tmpdir.as_cwd() as cwd:
+        yield tmpdir
 
 
 def test_execsetup(empty_setup_py: Path):
@@ -63,3 +73,100 @@ def test_full(testpkg1):
         readme-renderer >= 16.0
         flake8
         pep8-naming''')
+
+
+def _setup_cfg_merge_params():
+    params = [
+        # Basic
+        ({
+            'setup.py':
+            """
+            from setuptools import setup, find_packages
+
+            setup(packages=find_packages())
+            """,
+            'setup.cfg': """
+            [metadata]
+            name=foo
+            version=1.0.0
+            """,
+        },
+        {
+            'metadata': {
+                'name': 'foo',
+                'version': '1.0.0',
+            },
+            'options': {'packages': 'find:'},
+        }),
+        # Merging the "options" section
+        ({
+            'setup.py':
+            """
+            from setuptools import setup, find_packages
+
+            setup(packages=find_packages())
+            """,
+            'setup.cfg': """
+            [metadata]
+            name=foo
+            version=1.0.0
+
+            [options]
+            install_requires=python-dateutil
+            """,
+        },
+        {
+            'metadata': {
+                'name': 'foo',
+                'version': '1.0.0',
+            },
+            'options': {
+                'install_requires': 'python-dateutil',
+                'packages': 'find:',
+            }
+        }),
+        # Both add a section
+        ({
+            'setup.py':
+            """
+            from setuptools import setup
+
+            setup(extras_require={
+                'tests': ['pytest'],
+            })
+            """,
+            'setup.cfg': """
+            [metadata]
+            name=foo
+            version=1.0.0
+
+            [options]
+            install_requires=python-dateutil
+            """,
+        },
+        {
+            'metadata': {
+                'name': 'foo',
+                'version': '1.0.0',
+            },
+            'options': {
+                'install_requires': 'python-dateutil',
+            },
+            'options.extras_require': {
+                'tests': 'pytest',
+            },
+        }),
+    ]
+
+    return params
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize('files, expected', _setup_cfg_merge_params())
+def test_setup_cfg_merge(files, expected, tmpdir_cwd):
+    generate_package(tmpdir_cwd, files)
+
+    res = setuptools_py2cfg.main([str(tmpdir_cwd / 'setup.py')])
+
+    assert compare_configs(res, expected), configs_to_str(res, expected)
+

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,85 @@
+from functools import singledispatch
+from pathlib import Path
+
+import io
+from configparser import ConfigParser
+
+import textwrap
+
+from typing import Dict, Union, Any, Tuple
+
+_CONFIG_FROM = Union[
+    str,
+    Path,
+    io.IOBase,
+    Dict[str, Dict[str, Any]],
+    ConfigParser
+]
+
+
+__all__ = ['generate_package', 'compare_configs', 'configs_to_str']
+
+
+def generate_package(root_path: Path, files: Dict[Union[str,Path], str]):
+    """
+    Given a root path and a dictionary mapping relative file paths to their
+    contents, create the file hierarchy
+    """
+    for rel_path, contents in files.items():
+        fpath = root_path / rel_path
+
+        with open(fpath, 'w') as f:
+            f.write(textwrap.dedent(contents))
+
+
+def compare_configs(cfg1: _CONFIG_FROM, cfg2: _CONFIG_FROM) -> ConfigParser:
+    return _to_config(cfg1) == _to_config(cfg2)
+
+
+def configs_to_str(*cfgs: ConfigParser) -> Tuple[str, ...]:
+    return tuple(map(_config_to_str, cfgs))
+
+
+def _config_to_str(cfg: ConfigParser) -> str:
+    cfg = _to_config(cfg)
+
+    s = io.StringIO()
+    cfg.write(s)
+    s.seek(0)
+    return s.read()
+
+
+@singledispatch
+def _to_config(cfg):
+    raise ValueError(f"Cannot convert to config file: {cfg!r}")
+
+@_to_config.register(dict)
+def _(cfg):
+    cfg_out = ConfigParser()
+    cfg_out.read_dict(cfg)
+    return cfg_out
+
+@_to_config.register(str)
+def _(cfg):
+    s = io.StringIO(cfg)
+    return _to_config(s)
+
+
+@_to_config.register(Path)
+def _(cfg):
+    with open(cfg, 'r') as f:
+        return _to_config(f)
+
+
+@_to_config.register(io.IOBase)
+def _(cfg):
+    cfg_out = ConfigParser()
+    cfg_out.read_file(cfg)
+
+    return cfg_out
+
+
+@_to_config.register(ConfigParser)
+def _(cfg):
+    return cfg
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+minversion=2.9.0
+envlist=py37
+
+[testenv]
+description=Run the unit tests with pytest under {basepython}
+commands = pytest {toxinidir} {posargs}
+deps=
+    pytest
+


### PR DESCRIPTION
This fixes #6.

I also added some convenience functions for the test utilities to make it easier to write these and future tests, as well as a `tox.ini`.

Might be a good idea to set up Travis CI.