### PR TITLE
Write output to stdout instead of stderr.

### DIFF
--- a/setuptools_py2cfg.py
+++ b/setuptools_py2cfg.py
@@ -15,7 +15,7 @@ from unittest.mock import Mock
 from configparser import ConfigParser
 
 
-def parseargs(args=None):
+def parseargs(cli_args=None):
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter, description=__doc__)
 
     parser.add_argument(
@@ -34,7 +34,7 @@ def parseargs(args=None):
         'setup_py', type=FileType('r'), default='./setup.py', nargs='?', metavar='path',
         help='path to setup.py file')
 
-    return parser.parse_args(args)
+    return parser.parse_args(cli_args)
 
 
 def execsetup(setup_py: Path):
@@ -55,8 +55,13 @@ def execsetup(setup_py: Path):
     return setuptools.setup.call_args[1], setuppy_dir
 
 
-def main(args=None):
-    args = parseargs(args)
+def main(cli_args=None):
+    # Wrap _main() to test the output And avoid printing to stderr when running from the cli.
+    print(_main(cli_args))
+
+
+def _main(cli_args=None):
+    args = parseargs(cli_args)
     setup, setuppy_dir = execsetup(Path(args.setup_py.name).resolve())
     metadata, options, sections = py2cfg(setup, setuppy_dir, args.dangling_list_threshold)
 

--- a/tests/test_py2cfg.py
+++ b/tests/test_py2cfg.py
@@ -33,7 +33,7 @@ def test_execsetup(empty_setup_py: Path):
 
 
 def test_full(testpkg1):
-    res = setuptools_py2cfg.main([str(testpkg1 / 'setup.py')])
+    res = setuptools_py2cfg._main([str(testpkg1 / 'setup.py')])
     assert res == textwrap.dedent('''\
     [metadata]
     name = ansimarkup
@@ -165,7 +165,7 @@ def _setup_cfg_merge_params():
 def test_setup_cfg_merge(files, expected, tmpdir_cwd):
     generate_package(tmpdir_cwd, files)
 
-    res = setuptools_py2cfg.main([str(tmpdir_cwd / 'setup.py')])
+    res = setuptools_py2cfg._main([str(tmpdir_cwd / 'setup.py')])
 
     assert compare_configs(res, expected), configs_to_str(res, expected)
 


### PR DESCRIPTION
Wraps the `main()` function in order to continue to test on `io.StringIO` elements without having to extract it from stdout while printing it for the cli tool.

This addresses a small issue I had by auto-generating the `setup.cfg` file using `setuptools_py2cfg ./setup.py > setup.cfg`

All tests are passing.

This should be considered as breaking change that could require a major version bump.