### PR TITLE
setup.cfg: install_requires = setuptools; python_version>=3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ zip_safe = True
 py_modules = setuptools_py2cfg
 python_requires = >=3.3
 install_requires =
-    setuptools; python_version>=3.12
+    setuptools; python_version>="3.12"
 
 [options.extras_require]
 test = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
 zip_safe = True
 py_modules = setuptools_py2cfg
 python_requires = >=3.3
+install_requires =
+    setuptools; python_version>=3.12
 
 [options.extras_require]
 test = pytest

--- a/setuptools_py2cfg.py
+++ b/setuptools_py2cfg.py
@@ -41,7 +41,7 @@ def parseargs(cli_args=None):
 def execsetup(setup_py: Path):
     # Mock all function in the setuptools module.
     global setuptools
-    sys.modules['setuptools'] = Mock(spec=setuptools)
+    sys.modules['setuptools'] = Mock(autospec=setuptools)
     import setuptools
 
     cwd = Path.cwd()


### PR DESCRIPTION
```
% python3.12 -m pip install pipx
% pipx install setuptools-py2cfg
% setuptools-py2cfg
```
> Traceback (most recent call last):
  File "/Users/cclauss/.local/bin/setuptools-py2cfg", line 5, in <module>
    from setuptools_py2cfg import main
  File "/Users/cclauss/.local/pipx/venvs/setuptools-py2cfg/lib/python3.12/site-packages/setuptools_py2cfg.py", line 7, in <module>
    import setuptools
ModuleNotFoundError: No module named 'setuptools'
---
Fix: `pipx inject setuptools-py2cfg setuptools`

---
https://docs.python.org/3.12/whatsnew/3.12.html
> [gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install setuptools in virtual environments created with [venv](https://docs.python.org/3.12/library/venv.html#module-venv). This means that distutils, setuptools, pkg_resources, and easy_install will no longer available by default; to access these run pip install setuptools in the [activated](https://docs.python.org/3.12/library/venv.html#venv-explanation) virtual environment.