### PR TITLE
install_requires = setuptools; python_version>="3.12" and upgrade GitHub Actions

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,5 +8,5 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install tox
+      - run: pip install setuptools tox
       - run: tox -e py

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -8,5 +8,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: pip install setuptools tox
+      - run: pip install tox
+      - run: pip install --editable .
       - run: tox -e py

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,8 +4,8 @@ jobs:
   tox:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: pip install tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
 zip_safe = True
 py_modules = setuptools_py2cfg
 python_requires = >=3.3
+install_requires =
+    setuptools; python_version>="3.12"
 
 [options.extras_require]
 test = pytest

--- a/setuptools_py2cfg.py
+++ b/setuptools_py2cfg.py
@@ -41,7 +41,7 @@ def parseargs(cli_args=None):
 def execsetup(setup_py: Path):
     # Mock all function in the setuptools module.
     global setuptools
-    sys.modules['setuptools'] = Mock(spec=setuptools)
+    sys.modules['setuptools'] = Mock(autospec=setuptools)
     import setuptools
 
     cwd = Path.cwd()

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 minversion=2.9.0
-envlist=py37
+envlist=py38,py39,py310,py311,py312
 
 [testenv]
 description=Run the unit tests with pytest under {basepython}
 commands = pytest {toxinidir} {posargs}
 deps=
     pytest
-    setuptools; python_version>="3.12"

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,4 @@ description=Run the unit tests with pytest under {basepython}
 commands = pytest {toxinidir} {posargs}
 deps=
     pytest
-
+    setuptools; python_version>="3.12"


### PR DESCRIPTION
@gvalkov Your review, please.

Fixes #8 
Fixes #10 
Fixes #22
Fixes #23 
* #8
* #10 
* #22
* #23
---

[distutils](https://docs.python.org/3/library/distutils.html#module-distutils) is deprecated with removal planned for Python 3.12. See the [What’s New](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated) entry for more information.
```
install_requires =
    setuptools; python_version>="3.12"
```
---

[`Mock(spec)` --> `Mock(autospec)`](https://github.com/gvalkov/setuptools-py2cfg/pull/24/commits/ab9f766e4483e78d3695a5e25a368e080cdfbebe)
https://github.com/gvalkov/setuptools-py2cfg/blob/7299f1c9f11f0d455c244d5a51ca95c3cc34dbfc/setuptools_py2cfg.py#L44
* https://nedbatchelder.com/blog/202202/why_your_mock_still_doesnt_work.html