### PR TITLE
PEP8: Avoid bare except

### DIFF
--- a/setuptools_py2cfg.py
+++ b/setuptools_py2cfg.py
@@ -217,7 +217,7 @@ def find_file(content, setuppy_dir):
         try:
             if path.read_text() == content:
                 return "file: %s" % path.name
-        except:
+        except Exception:
             pass
     return content
 


### PR DESCRIPTION
```diff
-        except:
+        except Exception:
```
https://pep8.org/#programming-recommendations

https://docs.astral.sh/ruff/rules/bare-except/#bare-except-e722